### PR TITLE
Add multi-repo support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<!-- Parent Project Information -->
 	<groupId>io.yukon</groupId>
 	<artifactId>gitpull</artifactId>
-	<version>1.0.1-SNAPSHOT</version>
+	<version>2.0.0-SNAPSHOT</version>
 	<name>GitPull</name>
 
 	<!-- Repository Locations -->

--- a/src/main/java/io/yukon/gitpull/GitCommands.java
+++ b/src/main/java/io/yukon/gitpull/GitCommands.java
@@ -3,47 +3,84 @@ package io.yukon.gitpull;
 import co.aikar.commands.BaseCommand;
 import co.aikar.commands.CommandHelp;
 import co.aikar.commands.annotation.CommandAlias;
+import co.aikar.commands.annotation.CommandCompletion;
 import co.aikar.commands.annotation.CommandPermission;
+import co.aikar.commands.annotation.Default;
 import co.aikar.commands.annotation.Dependency;
 import co.aikar.commands.annotation.Description;
 import co.aikar.commands.annotation.HelpCommand;
 import co.aikar.commands.annotation.Subcommand;
-import org.bukkit.ChatColor;
+import co.aikar.commands.annotation.Syntax;
+import com.google.common.collect.Lists;
+import io.yukon.gitpull.GitPull.CachedRepo;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.List;
+import java.util.Optional;
+import net.md_5.bungee.api.ChatColor;
+import net.md_5.bungee.api.chat.BaseComponent;
+import net.md_5.bungee.api.chat.ClickEvent;
+import net.md_5.bungee.api.chat.ComponentBuilder;
+import net.md_5.bungee.api.chat.HoverEvent;
+import net.md_5.bungee.api.chat.TextComponent;
 import org.bukkit.command.CommandException;
 import org.bukkit.command.CommandSender;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
-import org.eclipse.jgit.lib.Repository;
 import org.eclipse.jgit.revwalk.RevCommit;
 
-@CommandAlias("git")
+@CommandAlias("git|gitpull")
 @Description("Commands for managing a git repo.")
 public class GitCommands extends BaseCommand {
 
+  public static final String DIV = ChatColor.GOLD + "\u00BB ";
+
   @Dependency private GitPull plugin;
 
-  @Dependency private Repository repo;
-
-  @Subcommand("reload")
+  @Subcommand("reload|reloadconfig")
   @Description("Reloads GitPull config")
   @CommandPermission("gitpull.reload")
-  public void reload(CommandSender sender) throws CommandException {
+  public void reload(final CommandSender sender) throws CommandException {
     plugin.reloadConfig();
     sender.sendMessage(ChatColor.GREEN + "GitPull config reloaded!");
   }
 
-  @CommandAlias("pull") // Command Alias so we can do /git pull or /pull
-  @Subcommand("pull|update")
-  @Description("Pulls the latest remote repo")
-  @CommandPermission("gitpull.reload")
-  public void pull(final CommandSender sender) throws CommandException {
+  @Subcommand("status")
+  @Description("View repo status of an individual repo")
+  @CommandPermission("gitpull.status")
+  @CommandCompletion("@repos")
+  @Syntax("[repo] - Name of the target repo")
+  public void status(final CommandSender sender, String repoName) {
+    Optional<CachedRepo> repo = plugin.getRepo(repoName);
+
+    if (repo.isPresent()) {
+      plugin
+          .getServer()
+          .getScheduler()
+          .runTaskAsynchronously(
+              plugin,
+              new Runnable() {
+                @Override
+                public void run() {
+                  sendRepoStatus(sender, repo.get(), false);
+                }
+              });
+    } else {
+      sender.sendMessage(format("&cNo repo with name &e%s&c was found!", repo));
+    }
+  }
+
+  @Subcommand("list|ls")
+  @Description("View a list of loaded repos")
+  @CommandPermission("gitpull.list")
+  public void list(final CommandSender sender) {
+    if (plugin.getRepos().isEmpty()) {
+      sender.sendMessage(ChatColor.RED + "No git repos found!");
+      return;
+    }
     sender.sendMessage(
-        ChatColor.GRAY
-            + "Now pulling "
-            + ChatColor.GREEN
-            + plugin.repoName()
-            + ChatColor.GRAY
-            + "...");
+        format("&7&m-------&r &aGit Repos &7(&b%d&7) &7&m-------&r", plugin.getRepos().size()));
+
     plugin
         .getServer()
         .getScheduler()
@@ -52,37 +89,126 @@ public class GitCommands extends BaseCommand {
             new Runnable() {
               @Override
               public void run() {
-                pullRepo(sender);
+                plugin.getRepos().forEach(repo -> sendRepoStatus(sender, repo, true));
               }
             });
   }
 
+  private void sendRepoStatus(CommandSender sender, CachedRepo repo, boolean hover) {
+    List<BaseComponent> extras = Lists.newArrayList();
+    BaseComponent text = new TextComponent(format("&a%s&7 - ", repo.getName()));
+    BaseComponent secondLine = null;
+
+    // Pull Button
+    TextComponent button =
+        new TextComponent(ChatColor.GRAY + "[" + ChatColor.YELLOW + "Pull" + ChatColor.GRAY + "]");
+    button.setHoverEvent(
+        new HoverEvent(
+            HoverEvent.Action.SHOW_TEXT,
+            new ComponentBuilder(ChatColor.GRAY + "Click to pull the latest remote changes!")
+                .create()));
+    button.setClickEvent(
+        new ClickEvent(ClickEvent.Action.RUN_COMMAND, "/git pull " + repo.getName()));
+
+    try {
+      Git git = new Git(repo.getRepo());
+      RevCommit commit = git.log().setMaxCount(1).call().iterator().next();
+
+      TextComponent commitID = new TextComponent(commit.abbreviate(7).name());
+      commitID.setColor(ChatColor.GREEN);
+      commitID.addExtra(" ");
+
+      DateFormat date = SimpleDateFormat.getInstance();
+      String msgAuthor =
+          format(
+              "&7Commit by &b%s &7on &3%s &7:&e %s",
+              commit.getAuthorIdent().getName(),
+              date.format(commit.getAuthorIdent().getWhen()),
+              commit.getShortMessage());
+
+      if (hover) {
+        commitID.setHoverEvent(
+            new HoverEvent(HoverEvent.Action.SHOW_TEXT, new ComponentBuilder(msgAuthor).create()));
+      } else {
+        secondLine = new TextComponent(DIV + msgAuthor);
+      }
+
+      extras.add(commitID);
+    } catch (GitAPIException e) {
+      // Just omit if fails...
+    }
+
+    if (hover) {
+      extras.add(button);
+    }
+    text.setExtra(extras);
+
+    sender.sendMessage(text);
+    if (secondLine != null) {
+      sender.sendMessage(secondLine);
+    }
+  }
+
+  @Subcommand("pull|update")
+  @Description("Pulls the latest remote repo")
+  @Syntax("[repo] - Name of the target repo, * for all")
+  @CommandPermission("gitpull.reload")
+  @CommandCompletion("@repos")
+  public void pull(final CommandSender sender, @Default("*") String repoName)
+      throws CommandException {
+    boolean all = (repoName.equalsIgnoreCase("*") || repoName.equalsIgnoreCase("all"));
+    if (all) {
+      plugin.getRepos().forEach(r -> pullRepo(sender, r));
+    } else {
+      Optional<CachedRepo> repo = plugin.getRepo(repoName);
+      if (repo.isPresent()) {
+        pullRepo(sender, repo.get());
+      } else {
+        sender.sendMessage(format("&cNo repo with name &e%s&c was found!", repoName));
+      }
+    }
+  }
+
   @HelpCommand
-  public void git(CommandSender sender, CommandHelp help) {
+  @Description("Display the help page")
+  public void git(final CommandSender sender, CommandHelp help) {
     help.showHelp();
   }
 
-  private void pullRepo(CommandSender sender) {
-    try {
-      Git git = new Git(repo);
-      git.pull().call();
-      RevCommit commit = git.log().setMaxCount(1).call().iterator().next();
-      sender.sendMessage(
-          ChatColor.GREEN + plugin.repoName() + ChatColor.GRAY + " was successfully pulled!");
-      sender.sendMessage(
-          ChatColor.GRAY
-              + "Commit by "
-              + ChatColor.AQUA
-              + commit.getAuthorIdent().getName()
-              + ChatColor.GRAY
-              + ": "
-              + ChatColor.YELLOW
-              + commit.getShortMessage());
-      git.close();
-    } catch (GitAPIException e) {
-      e.printStackTrace();
-      throw new CommandException(
-          "An error has occurred, repo not updated.\n" + e.getCause().getMessage());
-    }
+  private void pullRepo(final CommandSender sender, CachedRepo repo) {
+    sender.sendMessage(format("&7Now pulling &a%s&7...", repo.getName()));
+
+    plugin
+        .getServer()
+        .getScheduler()
+        .runTaskAsynchronously(
+            plugin,
+            new Runnable() {
+              @Override
+              public void run() {
+                try {
+                  Git git = new Git(repo.getRepo());
+                  git.pull().call();
+                  RevCommit commit = git.log().setMaxCount(1).call().iterator().next();
+                  sender.sendMessage(format("&a%s &7was successfully pulled!", repo.getName()));
+                  sender.sendMessage(
+                      format(
+                          "%s&7Commit &a%s&7 by &b%s&7: %s",
+                          DIV,
+                          commit.abbreviate(7).name(),
+                          commit.getAuthorIdent().getName(),
+                          commit.getShortMessage()));
+                  git.close();
+                } catch (GitAPIException e) {
+                  e.printStackTrace();
+                  throw new CommandException(
+                      "An error has occurred, repo not updated.\n" + e.getCause().getMessage());
+                }
+              }
+            });
+  }
+
+  private String format(String format, Object... args) {
+    return ChatColor.translateAlternateColorCodes('&', String.format(format, args));
   }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,11 +1,24 @@
-# Repo-name - The name of the repo
+#
+# GitPull
+# Created by Yukon and updated by applenick
+#
+
+# ssh-passphrase - The passpharse provided to JVM to auth git access
+# Learn more about SSH https://help.github.com/en/github/authenticating-to-github/about-ssh
+ssh-passphrase: password
+
+ 
+# repo-name: - The name of the repo
 # Notes: This does not do anything, only used when notifying command sender.
 # (But defined makes the command feedback better ;D)
-repo-name: Repo
-
+# 
 # repo-path: The directory path to the git repo. 
 # Notes: Ensure this points to the root folder of a repo. A sub-folder may cause problems
-repo-path: /
 
-# ssh-passphrase - The passpharse if required
-ssh-passphrase: password
+repositories:
+  repo1:
+    repo-name: "First Repo"
+    repo-path: /path1/
+  repo2:
+    repo-name: "Second Repo"
+    repo-path: /path2/


### PR DESCRIPTION
# Multi-Repo support
* New commands /git status and /git list
* Bump version to 2.0.0


Screenshots:

Performing `/git list` will display a list of loaded git repos.  Including a button to start a git pull.
![Screen Shot 2020-04-10 at 5 38 01 PM](https://user-images.githubusercontent.com/3377659/79031575-7cd49f80-7b54-11ea-8fbc-37843ccef935.png)

Also hover over the commit to display some extended into if desired.
![Screen Shot 2020-04-10 at 5 38 53 PM](https://user-images.githubusercontent.com/3377659/79031572-76462800-7b54-11ea-9ff7-4b753718bec8.png)

Example of pulling a repo (`/git pull`)
![Screen Recording 2020-04-10 at 05 40 PM](https://user-images.githubusercontent.com/3377659/79031593-a55c9980-7b54-11ea-9a5e-acccd8a4593f.gif)

Example of viewing a repo status (`/git status`)
![Screen Recording 2020-04-10 at 05 42 PM](https://user-images.githubusercontent.com/3377659/79031596-a7bef380-7b54-11ea-8757-2a9a5bfc1436.gif)

Command `/git` or `/git help` will display this nice help menu.
![Screen Shot 2020-04-10 at 5 42 49 PM](https://user-images.githubusercontent.com/3377659/79031570-70e8dd80-7b54-11ea-8394-9c8c7fe0a3ba.png)

Signed-off-by: applenick <applenick@users.noreply.github.com>